### PR TITLE
include/sexp/sexp-error.h: fix missing cstdint include

### DIFF
--- a/.github/workflows/build-and-test-deb.yml
+++ b/.github/workflows/build-and-test-deb.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ 'i386/debian:9', 'i386/debian:11', 'amd64/debian:11' ]
+        image: [ 'i386/debian:10', 'i386/debian:11', 'amd64/debian:11' ]
         env: [ {CC: gcc, CXX: g++}, {CC: clang, CXX: clang++} ]
     container: ${{ matrix.image }}
     env: ${{ matrix.env }}

--- a/include/sexp/sexp-error.h
+++ b/include/sexp/sexp-error.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
With gcc-13 and probably clang-16 compilation fails to:
```
FAILED: CMakeFiles/sexp.dir/src/sexp-error.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++  -I/var/tmp/portage/dev-libs/sexp-0.8.3/work/sexp-0.8.3/include  -march=native -O2 -pipe -frecord-gcc-switches -fPIC -Wall -Wextra -Wunreachable-code -Wpointer-arith -Wmissing-declarations -Wno-pedantic -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-missing-field-initializers -MD -MT CMakeFiles/sexp.dir/src/sexp-error.cpp.o -MF CMakeFiles/sexp.dir/src/sexp-error.cpp.o.d -o CMakeFiles/sexp.dir/src/sexp-error.cpp.o -c /var/tmp/portage/dev-libs/sexp-0.8.3/work/sexp-0.8.3/src/sexp-error.cpp
In file included from /var/tmp/portage/dev-libs/sexp-0.8.3/work/sexp-0.8.3/src/sexp-error.cpp:30:
/var/tmp/portage/dev-libs/sexp-0.8.3/work/sexp-0.8.3/include/sexp/sexp-error.h:66:5: error: 'uint32_t' does not name a type
   66 |     uint32_t            get_position(void) const { return position; };
      |     ^~~~~~~~
/var/tmp/portage/dev-libs/sexp-0.8.3/work/sexp-0.8.3/include/sexp/sexp-error.h:34:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   33 | #include <iostream>
  +++ |+#include <cstdint>
   34 | #include <string>
```