### PR TITLE
Explicitly indicate library versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,18 @@ target_include_directories(sexp PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+string(REGEX MATCH "^([0-9]+)\\.[0-9]+\\.[0-9]+$" vmatches "${SEXP_VERSION}")
+if (NOT vmatches)
+  message(FATAL_ERROR "Failed to extract major version from SEXP_VERSION (${SEXP_VERSION}).")
+endif()
+set(SEXP_MAJOR_VERSION "${CMAKE_MATCH_1}")
+
 set_target_properties(sexp PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  VERSION "${SEXP_VERSION}"
+  SOVERSION "${SEXP_MAJOR_VERSION}"
 )
 
 if(WITH_SEXP_CLI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,10 @@ target_include_directories(sexp PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-set_target_properties(sexp PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(sexp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_target_properties(sexp PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 
 if(WITH_SEXP_CLI)
     add_executable (sexp-cli


### PR DESCRIPTION
C (and C++) libraries explicitly indicate versions, so that when they are dynamically loaded they can ensure version compatibility.

This brief series commits the library to maintaining backward ABI compatibility unless the  major version of the library changes.

I wrote this patch as i'm trying to packaging this library for debian, and this brings it in line with how other debian libraries are typically shipped.