### PR TITLE
Add a manpage for the sexp CLI

### DIFF
--- a/sexp.1
+++ b/sexp.1
@@ -1,0 +1,67 @@
+.TH SEXP "1" "June 2023" "sexp" "User Commands"
+
+.SH NAME
+
+sexp - Read, parse, and print out S-expressions
+
+.SH SYNOPSIS
+
+.B cat certificate-file | sexp -a -x
+
+.SH DESCRIPTION
+
+\fBsexp\fP typically reads an S-expression from standard input and rewrites it to standard output.
+
+Running without switches implies: -p -a -b -c -x
+
+.SH INPUT OPTIONS
+
+.B -i filename
+Takes input from file instead of stdin.
+.TP
+.B -p
+Prompts user for console input.
+.TP
+.B -s
+Treat input up to EOF as a single string, instead of parsing.
+
+.SH CONTROL LOOP
+
+The main routine typically reads one S-expression, prints it out again, and stops.  This may be modified:
+.TP
+.B -x
+Execute main loop repeatedly until end of file.
+
+.SH OUTPUT OPTIONS
+
+The output format is normally canonical, but this can be changed.
+More than one output format can be requested at once.
+
+.TP
+.B -o filename
+Write output to file instead of stdout.
+.TP
+.B -a
+Write output in advanced transport format.
+.TP
+.B -b
+Write output in base-64 output format.
+.TP
+.B -c
+Write output in canonical format.
+.TP
+.B -l
+Suppress linefeeds after output.
+.TP
+.B -w width
+Changes line width to specified width (0 implies no line-width constraint). Default: 75
+
+.SH AUTHOR
+
+The \fBsexp\fP project is maintained by Maxim Samsonov on behalf of Ribose, Inc.
+It is based on code from Ron Rivest and Butler Lampson.
+This manual page was written by Daniel Kahn Gillmor for the Debian project, but may be used by others.
+
+.SH SEE ALSO
+
+https://datatracker.ietf.org/doc/draft-rivest-sexp/


### PR DESCRIPTION
This is simple nroff format, written by hand from the -h output of `sexp`, so it can be shipped without worrying about any conversion utilities.

For future ease of maintenance, you might want to consider deriving the -h output, the argument parsing code, and the manpage all from the same source, so that a change in the command line interface can be done in a single location.

however, that kind of change is much more heavyweight and it probably depends on your preferred tooling, so i'm offering this simpler approach in the meantime.

Closes: #39