### PR TITLE
Add header to fix compilation with gcc 13

### DIFF
--- a/include/sexpp/sexp-error.h
+++ b/include/sexpp/sexp-error.h
@@ -27,6 +27,7 @@
 #include <exception>
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 #include "sexp-public.h"
 


### PR DESCRIPTION
While compiling rnp (with gcc 13) I had the following error:

In file included from /gctmp/vgeorgiev/rnp/BUILD/rnp-v0.17.0/src/libsexp/src/sexp-error.cpp:30:
/gctmp/vgeorgiev/rnp/BUILD/rnp-v0.17.0/src/libsexp/include/sexp/sexp-error.h:66:5: error: 'uint32_t' does not name a type
66 | uint32_t get_position(void) const { return position; };
| ^~~~~~~~
/gctmp/vgeorgiev/rnp/BUILD/rnp-v0.17.0/src/libsexp/include/sexp/sexp-error.h:34:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
33 | #include <iostream>
+++ |+#include <cstdint>
34 | #include <string>
make[2]: *** [src/libsexp/CMakeFiles/sexp.dir/build.make:146: src/libsexp/CMakeFiles/sexp.dir/src/sexp-error.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/gctmp/vgeorgiev/rnp/BUILD/rnp-v0.17.0/_build'
[ 6%] Built target rnp-common
make[2]: Leaving directory '/gctmp/vgeorgiev/rnp/BUILD/rnp-v0.17.0/_build'
make[1]: *** [CMakeFiles/Makefile2:1190: src/libsexp/CMakeFiles/sexp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

