### PR TITLE
sexp.h: fix inttypes include

### DIFF
--- a/include/sexpp/sexp.h
+++ b/include/sexpp/sexp.h
@@ -28,7 +28,11 @@
 
 #pragma once
 
-#include <inttypes.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <cinttypes>
 #include <climits>
 #include <limits>
 #include <cctype>


### PR DESCRIPTION
Fix the error with some platforms due to missing `__STDC_FORMAT_MACROS` define. Also use C++ header.